### PR TITLE
Fix including libobjc2's protocol.h instead of this one

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -20,7 +20,7 @@
 
 #include "internal.h"
 #if HAVE_MACH
-#include "protocol.h"
+#include "../src/protocol.h"
 #endif
 
 #if __linux__

--- a/src/source.c
+++ b/src/source.c
@@ -20,8 +20,8 @@
 
 #include "internal.h"
 #if HAVE_MACH
-#include "protocol.h"
-#include "protocolServer.h"
+#include "../src/protocol.h"
+#include "../src/protocolServer.h"
 #endif
 #include <sys/mount.h>
 


### PR DESCRIPTION
It's a bit hacky, but it works. Under arch linux, compilation fails if this patch is not applied.